### PR TITLE
Benchmark.times: include total time and number of times run in output

### DIFF
--- a/lib/benchmark.ex
+++ b/lib/benchmark.ex
@@ -87,13 +87,17 @@ defmodule Benchmark do
         b > a
       end)
 
+      total = List.foldl(tests, 0, fn({ t, _ }, sum) ->
+        t + sum
+      end)
+
       [ min: Benchmark.Time.at(elem(Enum.first(tests), 0)),
         max: Benchmark.Time.at(elem(List.last(tests), 0)),
 
         median: Benchmark.Time.at(elem(Enum.at(tests, round(length(tests) / 2)), 0)),
-        average: Benchmark.Time.at(List.foldl(tests, 0, fn({ t, _ }, sum) ->
-          t + sum
-        end) / length(tests)) ]
+        average: Benchmark.Time.at(total / length(tests)),
+        total: Benchmark.Time.at(total),
+        requested_number: unquote(n) ]
     end
   end
 


### PR DESCRIPTION
Both pieces of information are handy when you store the return value for later comparison of many return values -- simply because you often don't remember which settings you used exactly.
