### PR TITLE
Fixes for Elixir 1.0.2 + some abstractions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Benchmark.Mixfile do
   def project do
     [ app: :benchmark,
       version: "0.0.1",
-      elixir: "~> 0.12.2",
+      elixir: "~> 1.0.2",
       deps: deps ]
   end
 


### PR DESCRIPTION
- use latest version of elixir
- change `Records` to `Structs`
- remove redundant send/receive logic by using the `Task` abstraction
- remove unused code (`run_for_executor/4`) 
- fix default parameter syntax
